### PR TITLE
Remove . from local file check

### DIFF
--- a/lib/pip.js
+++ b/lib/pip.js
@@ -401,7 +401,7 @@ function filterRequirementsFile(source, target, options) {
     } else if (req === '') {
       return false;
     } else if (
-      (req.startsWith('file:') || (req.indexOf('.') != -1 || req.indexOf('/') != -1 || req.indexOf('\\') != -1)) &&
+      (req.startsWith('file:') || (req.indexOf('/') != -1 || req.indexOf('\\') != -1)) &&
       options.dockerizePip
     ) {
       localRequirements.push(req);


### PR DESCRIPTION
Fjerner sjekken på `.` fordi det gjorde at vanlig `requirements` syntaks ikke fungerte, ie. `<package-name==<version>` med dockerizePip. Jeg mener at der hvor denne er brukt kan vi heller bruke `-e .`.

Jeg synes også vi burde passe på å få med oss endringer fra det originale repoet?